### PR TITLE
Revert "Revert "use artifactory for image registry.""

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD_LOCALLY ?= 1
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the
 # IMAGE_REPO, IMAGE_NAME and RELEASE_TAG environment variable.
-IMAGE_REPO ?= quay.io/multicloudlab
+IMAGE_REPO ?= hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom
 IMAGE_NAME ?= go-repo-template
 
 # Github host to use for checking the source tree;
@@ -150,7 +150,8 @@ push-image: $(CONFIG_DOCKER_TARGET) build-image
 ############################################################
 
 multiarch-image: $(CONFIG_DOCKER_TARGET)
-	@common/scripts/multiarch_image.sh $(IMAGE_REPO) $(IMAGE_NAME) $(VERSION)
+	@echo "Do nothing for artifactory..."
+	# @common/scripts/multiarch_image.sh $(IMAGE_REPO) $(IMAGE_NAME) $(VERSION)
 
 ############################################################
 # clean section

--- a/common/scripts/config_docker.sh
+++ b/common/scripts/config_docker.sh
@@ -16,9 +16,9 @@
 #
 
 KUBECTL=$(command -v kubectl)
-DOCKER_REGISTRY="quay.io"
-DOCKER_USERNAME="multicloudlab"
-DOCKER_PASSWORD=$(${KUBECTL} -n default get secret quay-cred -o jsonpath='{.data.password}' | base64 --decode)
+DOCKER_REGISTRY="hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com"
+DOCKER_USERNAME=$(${KUBECTL} -n default get secret artifactory-cred -o jsonpath='{.data.username}' | base64 --decode)
+DOCKER_PASSWORD=$(${KUBECTL} -n default get secret artifactory-cred -o jsonpath='{.data.password}' | base64 --decode)
 
 # support other container tools, e.g. podman
 CONTAINER_CLI=${CONTAINER_CLI:-docker}


### PR DESCRIPTION
Reverts IBM/go-repo-template#83

Looks like some CS operators still need this for the new CICD pipeline, restoring this.